### PR TITLE
Add wrapper to compare multiple agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ You can test the environment by running one of the built-in agents:
 python gym_adserver/agents/ucb1_agent.py --num_ads 10 --impressions 10000
 ```
 
+Or comparing multiple agents (defined in compare_agents.py):
+
+```bash
+python gym_adserver/wrappers/compare_agents.py --num_ads 10 --impressions 10000
+```
+
 The environent will generate 10 (`num_ads`) ads with different performance rates and the agent, without prior knowledge, will learn to select the most performant ones. The simulation will last 10000 iterations (`impressions`).
 
 A window will open and show the agent's performance and the environment's state:
@@ -84,4 +90,3 @@ pytest -v
 - Implement [Q-learning](https://en.wikipedia.org/wiki/Q-learning) [agents](https://medium.com/swlh/introduction-to-q-learning-with-openai-gym-2d794da10f3d)
 - Implement a meta-agent that exploits multiple sub-agents with different algorithms
 - Implement epsilon-Greedy variants
-- Implement an environment/wrapper to run and compare multiple agents

--- a/gym_adserver/agents/epsilon_greedy_agent.py
+++ b/gym_adserver/agents/epsilon_greedy_agent.py
@@ -11,10 +11,10 @@ from gym import wrappers, logger
 import gym_adserver
 
 class EpsilonGreedyAgent(object):
-    def __init__(self, seed, espilon):
+    def __init__(self, seed, epsilon):
         self.name = "epsilon-Greedy Agent"
         self.np_random = RandomState(seed)
-        self.epsilon = espilon
+        self.epsilon = epsilon
 
     def act(self, observation, reward, done):
         ads, _, _ = observation

--- a/gym_adserver/envs/adserver.py
+++ b/gym_adserver/envs/adserver.py
@@ -77,7 +77,7 @@ class AdServerEnv(gym.Env):
         ads, impressions, clicks = self.state
         ctr = 0.0 if impressions == 0 else float(clicks / impressions)
 
-        logger.info('Impressions: {}, CTR: {}, Ads: {}'.format(impressions, ctr, ads))
+        logger.info('Scenario: {}, Impressions: {}, CTR: {}, Ads: {}'.format(self.scenario_name, impressions, ctr, ads))
 
         fig = plt.figure(num=self.scenario_name,figsize=(9, 6))
         grid_size = (5, 2)

--- a/gym_adserver/wrappers/compare_agents.py
+++ b/gym_adserver/wrappers/compare_agents.py
@@ -9,11 +9,16 @@ from gym_adserver.agents.random_agent import RandomAgent
 from gym_adserver.agents.softmax_agent import SoftmaxAgent
 from gym_adserver.agents.ucb1_agent import UCB1Agent
 
-
 def setup_environment(env_name, num_ads, time_series_frequency):
     env = gym.make(env_name, num_ads=num_ads, time_series_frequency=time_series_frequency)
     env.seed(args.seed)
     return env
+
+def render_environment(env, i, **kwargs):
+    if kwargs['output_file'] is not None:
+        kwargs['output_file'] = str(i) + "_" + kwargs['output_file']
+    env.render(**kwargs)
+    env.close()
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -39,11 +44,13 @@ if __name__ == '__main__':
         EpsilonGreedyAgent(seed=seed, epsilon=0.1),
     ]
 
-    # Simulation loop
     envs = []
     for agent in agents:
-        reward = 0
+        logger.info('Starting {}'.format(agent.name))
         env = setup_environment(env_name=args.env, num_ads=args.num_ads, time_series_frequency=time_series_frequency)
+
+        # Simulation loop
+        reward = 0
         observation = env.reset(agent.name)
         envs.append(env)
         for i in range(args.impressions):
@@ -53,4 +60,4 @@ if __name__ == '__main__':
 
     # Render result for each agent (NOTE: close all to quit)
     parallel = Parallel(n_jobs=-1)
-    parallel(delayed(env.render)(freeze=True, output_file=args.output_file) for env in envs)
+    parallel(delayed(render_environment)(env, i, freeze=True, output_file=args.output_file) for i, env in enumerate(envs))

--- a/gym_adserver/wrappers/compare_agents.py
+++ b/gym_adserver/wrappers/compare_agents.py
@@ -1,0 +1,56 @@
+import argparse
+
+import gym
+from gym import logger, spaces
+from joblib import Parallel, delayed
+
+from gym_adserver.agents.epsilon_greedy_agent import EpsilonGreedyAgent
+from gym_adserver.agents.random_agent import RandomAgent
+from gym_adserver.agents.softmax_agent import SoftmaxAgent
+from gym_adserver.agents.ucb1_agent import UCB1Agent
+
+
+def setup_environment(env_name, num_ads, time_series_frequency):
+    env = gym.make(env_name, num_ads=num_ads, time_series_frequency=time_series_frequency)
+    env.seed(args.seed)
+    return env
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--env', default='AdServer-v0')
+    parser.add_argument('--num_ads', type=int, default=10)
+    parser.add_argument('--impressions', type=int, default=10000)
+    parser.add_argument('--seed', type=int, default=0)
+    parser.add_argument('--output_file', default=None)
+    args = parser.parse_args()
+
+    logger.set_level(logger.INFO)
+
+    time_series_frequency = args.impressions // 10
+    action_space = spaces.Discrete(args.num_ads)
+    max_impressions = args.impressions
+    seed = args.seed
+
+    # Define your agents here
+    agents = [
+        RandomAgent(action_space=action_space),
+        SoftmaxAgent(seed=seed, beta=5, max_impressions=max_impressions),
+        UCB1Agent(action_space=action_space, seed=args.seed, c=2, max_impressions=max_impressions),
+        EpsilonGreedyAgent(seed=seed, epsilon=0.1),
+    ]
+
+    # Simulation loop
+    envs = []
+    for agent in agents:
+        reward = 0
+        env = setup_environment(env_name=args.env, num_ads=args.num_ads, time_series_frequency=time_series_frequency)
+        observation = env.reset(agent.name)
+        envs.append(env)
+        for i in range(args.impressions):
+            # Action/Feedback
+            ad_index = agent.act(observation=observation, reward=reward, done=False)
+            observation, reward, _, _ = env.step(ad_index)
+
+    # Render result for each agent (NOTE: close all to quit)
+    parallel = Parallel(n_jobs=-1)
+    parallel(delayed(env.render)(freeze=True, output_file=args.output_file) for env in envs)

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     keywords = ['openai', 'openai-gym', 'gym', 'environment', 'agent', 'rl', 'ads'],
     install_requires=[
         'gym',
+        'joblib',
         'numpy',
         'matplotlib',
         'pytest',


### PR DESCRIPTION
This PR addresses one of the open next steps by adding a script to compare multiple agents.
I used joblib to open all renders concurrently (note that you need to click close on all windows for them to actually close).

Currently the agents are defined in the script, because supplying arguments for each of them would not make things easier. 

Further I corrected a typo and updated the README.

Happy to hear your thoughts!